### PR TITLE
Support mock runnables

### DIFF
--- a/languages/elixir/runnables.scm
+++ b/languages/elixir/runnables.scm
@@ -2,7 +2,7 @@
 ; This matches the ExUnit test style.
 (
     (call
-        target: (identifier) @run (#any-of? @run "describe" "test" "property")
+        target: (identifier) @run (#any-of? @run "describe" "test" "property" "test_with_mock" "test_with_mocks")
     ) @_elixir-test
     (#set! tag elixir-test)
 )

--- a/languages/elixir/runnables.scm
+++ b/languages/elixir/runnables.scm
@@ -1,4 +1,4 @@
-; Macros `describe`, `test` and `property`.
+; Macros `describe`, `test`, `property`, `test_with_mock`, and `test_with_mocks`.
 ; This matches the ExUnit test style.
 (
     (call


### PR DESCRIPTION
Allow running tests on the macros (`test_with_mock` and `test_with_mocks`) which are defined by Mock library.
https://github.com/jjh42/mock?tab=readme-ov-file#test_with_mock---with_mock-helper