### PR TITLE
Bump heex-tree-sitter to v0.8.1

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -24,4 +24,4 @@ commit = "a2861e88a730287a60c11ea9299c033c7d076e30"
 
 [grammars.heex]
 repository = "https://github.com/phoenixframework/tree-sitter-heex"
-commit = "2e1348c3cf2c9323e87c2744796cf3f3868aa82a"
+commit = "008626a3fad379d17c81d5ed576edd9bd7a4fbf7"


### PR DESCRIPTION
Recent changes to HEEX made the old heex tree sitter really obvious. Bump it to the most recent one.
Before : 
<img width="568" alt="image" src="https://github.com/user-attachments/assets/2bdd8f25-c5c6-4bcb-ad14-a3bd216109f4" />

After : 
<img width="641" alt="image" src="https://github.com/user-attachments/assets/c81bbf94-a797-4e8e-88c5-696a74e7ecc9" />
