### PR TITLE
Fix indentation of multiline strings

### DIFF
--- a/languages/elixir/brackets.scm
+++ b/languages/elixir/brackets.scm
@@ -1,5 +1,6 @@
 ("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
+("\"\"\"" @open "\"\"\"" @close)
 ("\"" @open "\"" @close)
 ("do" @open "end" @close)

--- a/languages/elixir/config.toml
+++ b/languages/elixir/config.toml
@@ -7,6 +7,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
+    { start = "\"\"\"", end = "\n\"\"\"", close = true, newline = true, not_in = ["string", "comment"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]

--- a/languages/elixir/indents.scm
+++ b/languages/elixir/indents.scm
@@ -1,6 +1,13 @@
-(call) @indent
+[
+  (after_block)
+  (anonymous_function)
+  (catch_block)
+  (do_block)
+  (else_block)
+  (rescue_block)
+  (stab_clause)
+] @indent
 
-(_ "[" "]" @end) @indent
-(_ "{" "}" @end) @indent
-(_ "(" ")" @end) @indent
-(_ "do" "end" @end) @indent
+[
+  "end"
+] @outdent


### PR DESCRIPTION
Thank you for this great extension.

I had one quirk that when I tried to add a multiline string, the ending and string indentation was incorrect.

```elixir
# Current
@doc """
  My doc
  """

# Expected
@doc """
My doc
"""
```

This change seems to be fixing that and also improves indentation query to be more readable IMO (which I did not write and all credits are [for Helix](https://github.com/helix-editor/helix/blob/master/runtime/queries/elixir/indents.scm))