### PR TITLE
Add more injection support

### DIFF
--- a/languages/elixir/injections.scm
+++ b/languages/elixir/injections.scm
@@ -5,3 +5,43 @@
   (quoted_content) @injection.content)
  (#eq? @_sigil_name "H")
  (#set! injection.language "heex"))
+
+; Elixir Regular Expressions
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#match? @_sigil_name "^(R|r)$")
+ (#set! injection.language "regex")
+ (#set! injection.combined))
+
+; Elixir Markdown Documentation
+(unary_operator
+  operator: "@"
+  operand: (call
+  target: ((identifier) @_identifier (#match? @_identifier "^(module|type|short)?doc$"))
+    (arguments [
+      (string (quoted_content) @injection.content)
+      (sigil (quoted_content) @injection.content)
+  ])) (#set! injection.language "markdown"))
+
+; Jason Sigils
+((sigil
+  (sigil_name) @_sigil_name
+  (quoted_content) @injection.content)
+ (#match? @_sigil_name "^(J|j)$")
+ (#set! injection.language "json")
+ (#set! injection.combined))
+
+; Phoenix Live View Component Macros
+(call
+  (identifier) @_identifier
+  (arguments
+    (atom)+
+    (keywords (pair
+      ((keyword) @_keyword (#eq? @_keyword "doc: "))
+      [
+        (string (quoted_content) @injection.content)
+        (sigil (quoted_content) @injection.content)
+      ]))
+  (#match? @_identifier "^(attr|slot)$")
+  (#set! injection.language "markdown")))


### PR DESCRIPTION
This adds injection support for

- Regex sigils
- Json sigils
- `@moduledoc`, `@typedoc` and `@shortdoc` markdowns
- Phoenix Component attr docs

Thanks to [Helix elixir](https://github.com/helix-editor/helix/blob/master/runtime/queries/elixir/injections.scm) which this config was based on.