### PR TITLE
Fix for Elixir LS 29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,3 @@
-#
-# zed-elixir
-#
-
 *.wasm
-
-#
-# Rust
-#
-
-/target
+target/
+grammars/

--- a/src/language_servers/elixir_ls.rs
+++ b/src/language_servers/elixir_ls.rs
@@ -45,7 +45,7 @@ impl ElixirLs {
             },
         )?;
 
-        let asset_name = format!("elixir-ls-{version}.zip", version = release.version,);
+        let asset_name = "elixir-ls.zip";
 
         let asset = release
             .assets
@@ -54,7 +54,7 @@ impl ElixirLs {
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
         let (platform, _arch) = zed::current_platform();
-        let version_dir = format!("elixir-ls-{}", release.version);
+        let version_dir = "elixir-ls";
         let extension = match platform {
             zed::Os::Mac | zed::Os::Linux => "sh",
             zed::Os::Windows => "bat",


### PR DESCRIPTION
Closes: https://github.com/zed-extensions/elixir/issues/16

Release filename changed:
- [elixir-ls v0.29.0](https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.29.0) is `elixir-ls.zip`
- [elixir-ls v0.28.0](https://github.com/elixir-lsp/elixir-ls/releases/tag/v0.28.0) (and earlier) are like `elixir-ls-v0.28.0.zip`