### PR TITLE
Add Expert language server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # zed-elixir
 #
 
+/grammars
 *.wasm
 
 #

--- a/extension.toml
+++ b/extension.toml
@@ -6,6 +6,10 @@ schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-extensions/elixir"
 
+[language_servers.expert]
+name = "Expert"
+languages = ["Elixir", "HEEX"]
+
 [language_servers.elixir-ls]
 name = "ElixirLS"
 languages = ["Elixir", "HEEX"]

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -1,7 +1,9 @@
 mod elixir_ls;
+mod expert;
 mod lexical;
 mod next_ls;
 
 pub use elixir_ls::*;
+pub use expert::*;
 pub use lexical::*;
 pub use next_ls::*;

--- a/src/language_servers/expert.rs
+++ b/src/language_servers/expert.rs
@@ -1,0 +1,134 @@
+use std::fs;
+
+use zed::LanguageServerId;
+use zed_extension_api::settings::LspSettings;
+use zed_extension_api::{self as zed, Result};
+
+pub struct ExpertBinary {
+    pub path: String,
+    pub args: Option<Vec<String>>,
+}
+
+pub struct Expert {
+    cached_binary_path: Option<String>,
+}
+
+impl Expert {
+    pub const LANGUAGE_SERVER_ID: &'static str = "expert";
+
+    pub fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    pub fn language_server_binary(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<ExpertBinary> {
+        let binary_settings = LspSettings::for_worktree("expert", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+        let binary_args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone());
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(ExpertBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(path) = worktree.which("expert") {
+            return Ok(ExpertBinary {
+                path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(path) = &self.cached_binary_path {
+            if fs::metadata(path).map_or(false, |stat| stat.is_file()) {
+                return Ok(ExpertBinary {
+                    path: path.clone(),
+                    args: binary_args,
+                });
+            }
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+        let release = zed::latest_github_release(
+            "elixir-lang/expert",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: true,
+            },
+        )?;
+
+        let (platform, arch) = zed::current_platform();
+        let asset_name = format!(
+            "expert_{os}_{arch}{extension}",
+            os = match platform {
+                zed::Os::Mac => "darwin",
+                zed::Os::Linux => "linux",
+                zed::Os::Windows => "windows",
+            },
+            arch = match arch {
+                zed::Architecture::Aarch64 => "arm64",
+                zed::Architecture::X8664 => "amd64",
+                zed::Architecture::X86 =>
+                    return Err(format!("unsupported architecture: {arch:?}")),
+            },
+            extension = match platform {
+                zed::Os::Mac | zed::Os::Linux => "",
+                zed::Os::Windows => ".exe",
+            }
+        );
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!("expert-{}", release.version);
+        fs::create_dir_all(&version_dir).map_err(|e| format!("failed to create directory: {e}"))?;
+
+        let binary_path = format!("{version_dir}/expert");
+
+        if !fs::metadata(&binary_path).map_or(false, |stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(
+                &asset.download_url,
+                &binary_path,
+                zed::DownloadedFileType::Uncompressed,
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)?;
+
+            let entries =
+                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+            for entry in entries {
+                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+                if entry.file_name().to_str() != Some(&version_dir) {
+                    fs::remove_dir_all(entry.path()).ok();
+                }
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(ExpertBinary {
+            path: binary_path,
+            args: binary_args,
+        })
+    }
+}


### PR DESCRIPTION
This PR adds support for [Expert](https://github.com/elixir-lang/expert), the official Elixir language server, which was just made available:

https://bsky.app/profile/expert-lsp.org/post/3lxifdssquc2p