### PR TITLE
Bump version to v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "zed_elixir"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "zed_extension_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_elixir"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "elixir"
 name = "Elixir"
 description = "Elixir support."
-version = "0.2.1"
+version = "0.2.2"
 schema_version = 1
 authors = ["Marshall Bowers <elliott.codes@gmail.com>"]
 repository = "https://github.com/zed-extensions/elixir"


### PR DESCRIPTION
This PR bumps the version of the extension to 0.2.2.

Includes:

- https://github.com/zed-extensions/elixir/pull/19