### PR TITLE
Injection support for comment parsing languages

### DIFF
--- a/languages/elixir/injections.scm
+++ b/languages/elixir/injections.scm
@@ -45,3 +45,7 @@
       ]))
   (#match? @_identifier "^(attr|slot)$")
   (#set! injection.language "markdown")))
+
+; Support comment parsing languages
+((comment) @injection.content
+  (#set! injection.language "comment"))


### PR DESCRIPTION
This allows parsing of comments to be done by 
extensions such as zed-comment for TODO parsing.