### PR TITLE
Download nightly build based on checksum

### DIFF
--- a/src/language_servers/expert.rs
+++ b/src/language_servers/expert.rs
@@ -120,13 +120,19 @@ impl Expert {
         let checksums_content = fs::read_to_string(&checksums_path)
             .map_err(|e| format!("failed to read checksums file: {e}"))?;
 
-        let checksum = checksums_content
+        fs::remove_dir_all(&checksums_dir)
+            .map_err(|e| format!("failed to remove checksums directory: {e}"))?;
+
+        let truncated_checksum = checksums_content
             .lines()
             .find(|line| line.ends_with(&asset_name))
             .and_then(|line| line.split_whitespace().next())
-            .ok_or_else(|| format!("checksum not found for {}", asset_name))?;
+            .ok_or_else(|| format!("checksum not found for {}", asset_name))?
+            .chars()
+            .take(8)
+            .collect::<String>();
 
-        let expert_dir = format!("{}-{}", Self::LANGUAGE_SERVER_ID, checksum);
+        let expert_dir = format!("{}-{}", Self::LANGUAGE_SERVER_ID, truncated_checksum);
         fs::create_dir_all(&expert_dir).map_err(|e| format!("failed to create directory: {e}"))?;
 
         let binary_path = format!("{expert_dir}/expert");


### PR DESCRIPTION
Should close https://github.com/zed-extensions/elixir/issues/42

Instead of downloading the nightly build to always the same folder `~/Library/Application\ Support/Zed/extensions/work/elixir/expert-nightly` which doesn't overwrite the existing installation since the `-nightly` suffix never changes, I use the checksum from the `expert_checksums.txt` file as a folder name - and therefore as a "version" which gets overwritten the next time a nightly release is pushed.

I closed the previous PR https://github.com/zed-extensions/elixir/pull/43 to move this to a feature branch