### PR TITLE
Adjust Elixir injections for markdown

### DIFF
--- a/languages/elixir/overrides.scm
+++ b/languages/elixir/overrides.scm
@@ -1,2 +1,6 @@
 (comment) @comment.inclusive
-[(string) (charlist)] @string
+
+[
+  (string)
+  (charlist)
+] @string


### PR DESCRIPTION
- Adds injections to `@deprecated` and `deprecated:` as well
- Ensure injections for markdown only happen in `~S` and `~s` sigils

Also rearranges the queries so that they are grouped slightly better