### PR TITLE
Improve Elixir text objects

### DIFF
--- a/languages/elixir/runnables.scm
+++ b/languages/elixir/runnables.scm
@@ -1,20 +1,16 @@
 ; Macros `describe`, `test`, `property`, `test_with_mock`, and `test_with_mocks`.
 ; This matches the ExUnit test style.
-(
-    (call
-        target: (identifier) @run (#any-of? @run "describe" "test" "property" "test_with_mock" "test_with_mocks")
-    ) @_elixir-test
-    (#set! tag elixir-test)
-)
+((call
+  target: (identifier) @run) @_elixir-test
+  (#any-of? @run "describe" "test" "property" "test_with_mock" "test_with_mocks")
+  (#set! tag elixir-test))
 
 ; Modules containing at least one `describe`, `test` and `property`.
 ; This matches the ExUnit test style.
-(
-    (call
-        target: (identifier) @run (#eq? @run "defmodule")
-        (do_block
-            (call target: (identifier) @_keyword (#any-of? @_keyword "describe" "test" "property"))
-        )
-    ) @_elixir-module-test
-    (#set! tag elixir-module-test)
-)
+((call
+  target: (identifier) @run
+  (do_block
+    (call target: (identifier) @_keyword
+      (#any-of? @_keyword "describe" "test" "property")))) @_elixir-module-test
+  (#eq? @run "defmodule")
+  (#set! tag elixir-module-test))


### PR DESCRIPTION
- Annotate all queries
- Adjust anonymous function definitions to account for multiple bodies
- Adjust function definitions to account for bodiless variants
- Include function definitions from `deftransform` and `deftransformp`
- Adjust `defdelegate`, `defguard`, and `defguardp` definitions
- Include documentation definitions from `@deprecated`
- Adjust documentation definitions to be more resilient

Also cleans up runnables queries