### PR TITLE
Add bracket detection for capture operator

### DIFF
--- a/languages/elixir/brackets.scm
+++ b/languages/elixir/brackets.scm
@@ -18,14 +18,18 @@
   "do" @open
   "end" @close)
 
-(call
-  (arguments
-    "(" @open
-    ")" @close))
+(arguments
+  "(" @open
+  ")" @close)
 
 (anonymous_function
   "fn" @open
   "end" @close)
+
+(unary_operator
+  operator: "&"
+  "(" @open
+  ")" @close)
 
 (interpolation
   "#{" @open

--- a/languages/elixir/indents.scm
+++ b/languages/elixir/indents.scm
@@ -6,7 +6,7 @@
   (bitstring ">>" @end)
   (do_block "end" @end)
   (anonymous_function "end" @end)
-  (call (arguments ")" @end))
+  (arguments ")" @end)
 ] @indent
 
 ; These have no end delimiter that can be captured,


### PR DESCRIPTION
Specifically when using parentheses as the delimiters - captures using curly and square bracket delimiters were already covered by the tuple and list detections

This also adjusts detection for argument parentheses - being inside a call node was far more restrictive than necessary