### PR TITLE
Improve HEEx highlights

### DIFF
--- a/languages/elixir/highlights.scm
+++ b/languages/elixir/highlights.scm
@@ -125,7 +125,7 @@
   quoted_end: _ @string.regex
   (#any-of? @_sigil_name "R" "r")) @string.regex
 
-; HEEx sigil
+; Phoenix HEEx template sigil
 (sigil
   (sigil_name) @string.special
   (quoted_content) @embedded

--- a/languages/heex/highlights.scm
+++ b/languages/heex/highlights.scm
@@ -1,27 +1,31 @@
-; HEEx delimiters
+; General HEEx tag delimiters are highlighted the same as HTML tag delimiters
 [
-  "/>"
-  "<!"
   "<"
+  "<!"
   "</"
-  "</:"
   "<:"
+  "</:"
   ">"
+  "/>"
+] @punctuation.bracket.html
+
+; HEEx expression delimiters
+[
   "{"
   "}"
 ] @punctuation.bracket
 
-[
-  "<%!--"
-  "<%"
-  "<%#"
-  "<%%="
-  "<%="
-  "%>"
-  "--%>"
-  "-->"
-  "<!--"
-] @keyword
+; HEEx partial expressions can use the following tag delimiters:
+;     `<%` and `%>`
+;     `<%=` and `%>`
+;     `<%%=` and `%>`
+(directive) @keyword
+
+; HEEx comments can use the following tag delimiters:
+;     `<!--` and `-->`
+;     `<%!--` and `--%>`
+;     `<%#` and `%>`
+(comment) @comment
 
 ; HEEx operators are highlighted as such
 "=" @operator
@@ -29,29 +33,33 @@
 ; HEEx inherits the DOCTYPE tag from HTML
 (doctype) @tag.doctype
 
-(comment) @comment
-
-; HEEx tags and slots are highlighted as HTML
+; HEEx tags and slots are highlighted the same as HTML tags
 [
  (tag_name)
  (slot_name)
 ] @tag
 
-; HEEx attributes are highlighted as HTML attributes
+; HEEx components are highlighted the same as Elixir modules and functions
+(component_name
+  [
+    (module) @type
+    (function) @function
+    "." @operator
+  ])
+
+; HEEx attributes are highlighted the same as HTML attributes
 (attribute_name) @attribute
 
-; HEEx special attributes are highlighted as keywords
+; HEEx special attributes can be any of the following:
+;     `:let`
+;     `:if`
+;     `:for`
+;     `:key`
+;     `:stream`
 (special_attribute_name) @keyword
 
+; HEEx attribute values are highlighted the same as HTML attribute values
 [
   (attribute_value)
   (quoted_attribute_value)
 ] @string
-
-; HEEx components are highlighted as Elixir modules and functions
-(component_name
-  [
-    (module) @module
-    (function) @function
-    "." @punctuation.delimiter
-  ])


### PR DESCRIPTION
Adjusts highlights for directive and comment delimiters; this makes it so that the `directive` node is targeted instead of the delimiters directly