### PR TITLE
Adjust HEEx config

### DIFF
--- a/languages/heex/config.toml
+++ b/languages/heex/config.toml
@@ -1,14 +1,20 @@
 name = "HEEX"
 grammar = "heex"
-path_suffixes = ["heex"]
-autoclose_before = ">})"
+path_suffixes = ["heex", "html.eex", "leex", "neex"]
+block_comment = { start = "<%!--", prefix = "", end = "--%>", tab_size = 0 }
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
+autoclose_before = ">})%"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "<", end = ">", close = true, newline = true },
+    { start = "%", end = "%", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "!--", end = " --", close = true, newline = false, not_in = ["string", "comment"] },
 ]
-block_comment = ["<%!-- ", " --%>"]
+tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 
 [overrides.string]

--- a/languages/heex/overrides.scm
+++ b/languages/heex/overrides.scm
@@ -1,3 +1,5 @@
+(comment) @comment.inclusive
+
 [
   (attribute_value)
   (quoted_attribute_value)


### PR DESCRIPTION
- Adds other suffixes that should be recognised as HEEx files
- Adjusts block comment configuration
- Adds auto-completion for a few other bracket delimiters
- Enforces a tab size of 2 by default (the formatter enforces this too)
- Adds override for comments