### PR TITLE
Add more syntax overrides

### DIFF
--- a/languages/elixir/config.toml
+++ b/languages/elixir/config.toml
@@ -4,21 +4,48 @@ path_suffixes = ["ex", "exs"]
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [
-    { start = "{", end = "}", close = true, newline = true },
-    { start = "[", end = "]", close = true, newline = true },
-    { start = "(", end = ")", close = true, newline = true },
-    { start = "do", end = "end", close = false, newline = true, not_in = ["string", "comment"] },
-    { start = "fn", end = "end", close = false, newline = true, not_in = ["string", "comment"] },
+    { start = "{", end = "}", close = true, newline = true, not_in = ["sigil_curly"] },
+    { start = "[", end = "]", close = true, newline = true, not_in = ["sigil_square"] },
+    { start = "(", end = ")", close = true, newline = true, not_in = ["sigil_round"] },
     { start = "<<", end = ">>", close = false, newline = true },
-    { start = "\"\"\"", end = "\n\"\"\"", close = true, newline = true, not_in = ["string", "comment"] },
-    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
-    { start = "'''", end = "\n'''", close = true, newline = true, not_in = ["string", "comment"] },
-    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "\"\"\"", end = "\n\"\"\"", close = true, newline = true, not_in = [
+        "comment",
+        "string",
+        "quoted_atom",
+        "sigil_string",
+    ] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+        "quoted_atom",
+        "sigil_string",
+    ] },
+    { start = "'''", end = "\n'''", close = true, newline = true, not_in = [
+        "comment",
+        "string",
+        "quoted_atom",
+        "sigil_string",
+    ] },
+    { start = "'", end = "'", close = true, newline = false, not_in = [
+        "comment",
+        "string",
+        "quoted_atom",
+        "sigil_string",
+    ] },
 ]
 tab_size = 2
 decrease_indent_pattern = '^\s*(after|catch|else|rescue)$'
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
 
 [overrides.string]
-word_characters = ["-"]
+completion_query_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]
+
+[overrides.identifier]
+word_characters = ["!", "?", "@"]
+
+[overrides.char]
+word_characters = ["\\"]
+
+[overrides.capture]
+word_characters = ["&"]

--- a/languages/elixir/overrides.scm
+++ b/languages/elixir/overrides.scm
@@ -4,3 +4,49 @@
   (string)
   (charlist)
 ] @string
+
+[
+  (quoted_atom)
+  (quoted_keyword)
+] @quoted_atom
+
+[
+  (identifier)
+  (atom)
+  (keyword)
+  (unary_operator
+    operator: "@")
+] @identifier
+
+(char) @char
+
+(unary_operator
+  operator: "&"
+  operand: (integer)) @capture
+
+(sigil
+  quoted_start: "{"
+  quoted_end: "}") @sigil_curly
+
+(sigil
+  quoted_start: "["
+  quoted_end: "]") @sigil_square
+
+(sigil
+  quoted_start: "("
+  quoted_end: ")") @sigil_round
+
+[
+  (sigil
+  quoted_start: "\"\"\""
+  quoted_end: "\"\"\"")
+  (sigil
+  quoted_start: "\""
+  quoted_end: "\"")
+  (sigil
+  quoted_start: "'''"
+  quoted_end: "'''")
+  (sigil
+  quoted_start: "'"
+  quoted_end: "'")
+] @sigil_string

--- a/languages/heex/config.toml
+++ b/languages/heex/config.toml
@@ -1,7 +1,7 @@
 name = "HEEX"
 grammar = "heex"
 path_suffixes = ["heex", "html.eex", "leex", "neex"]
-block_comment = { start = "<%!--", prefix = "", end = "--%>", tab_size = 0 }
+block_comment = { start = "<%!-- ", prefix = "", end = " --%>", tab_size = 0 }
 wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 autoclose_before = ">})%"
 brackets = [
@@ -10,9 +10,9 @@ brackets = [
     { start = "(", end = ")", close = true, newline = true },
     { start = "<", end = ">", close = true, newline = true },
     { start = "%", end = "%", close = true, newline = true },
-    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string", "comment"] },
-    { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
-    { start = "!--", end = " --", close = true, newline = false, not_in = ["string", "comment"] },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "'", end = "'", close = true, newline = false, not_in = ["comment", "string"] },
+    { start = "!--", end = " --", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
@@ -20,3 +20,6 @@ scope_opt_in_language_servers = ["tailwindcss-language-server"]
 [overrides.string]
 completion_query_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]
+
+[overrides.function]
+word_characters = ["!", "?"]

--- a/languages/heex/overrides.scm
+++ b/languages/heex/overrides.scm
@@ -1,6 +1,8 @@
-(comment) @comment.inclusive
+(comment) @comment
 
 [
   (attribute_value)
   (quoted_attribute_value)
 ] @string
+
+(function) @function


### PR DESCRIPTION
- Adds `!`, `?`, and `@` as word characters for identifiers
  - Does the same for HEEx, but only for the first two
- Adds `\` as a word character for char literals
- Adds `&` as a word character for parameter placeholders within anonymous function captures
- Disables bracket auto-closing within sigils using those brackets as delimiters
- Fixes Elixir completion query characters for Tailwind
- Fixes range inclusivity for comments override in HEEx