### PR TITLE
Adjust HEEx `directive` bracket detections

### DIFF
--- a/languages/heex/brackets.scm
+++ b/languages/heex/brackets.scm
@@ -4,12 +4,8 @@
 
 (directive
   _ @open
-  [
-    (expression_value)
-    (partial_expression_value)
-    (ending_expression_value)
-  ]
-  _ @close)
+  (_)
+  "%>" @close)
 
 (start_tag
   "<" @open


### PR DESCRIPTION
All `directive` nodes always end with `%>` and only ever contain one child node - the name of the node should not matter, so in case the grammar is updated to allow other nodes, this is more robust