### PR TITLE
Add more language server scopes

### DIFF
--- a/.tsqueryrc.json
+++ b/.tsqueryrc.json
@@ -100,13 +100,14 @@
       "char": "Captures char literals",
       "comment": "Captures block comments",
       "comment.inclusive": "Captures line comments",
-      "function": "Captures function identifiers",
-      "identifier": "Captures all identifiers (i.e. variables, functions, atoms, keywords, and attributes)",
+      "elixir": "Captures Elixir expressions",
+      "heex": "Captures HEEx templates",
+      "identifier": "Captures all identifiers (i.e. variables, functions, atoms, keywords, and module attributes)",
       "quoted_atom": "Captures quoted atoms",
       "sigil_curly": "Captures sigils using curly bracket delimiters",
-      "sigil_round": "Captures sigils using parenthesis delimiters",
+      "sigil_round": "Captures sigils using round bracket delimiters",
       "sigil_square": "Captures sigils using square bracket delimiters",
-      "sigil_string": "Captures sigils using string delimiters",
+      "sigil_quote": "Captures sigils using quote mark delimiters",
       "string": "Captures strings"
     },
     "redactions": {

--- a/languages/eex/config.toml
+++ b/languages/eex/config.toml
@@ -14,3 +14,17 @@ brackets = [
     { start = "!--", end = " --", close = true, newline = false, not_in = ["comment"] },
 ]
 tab_size = 2
+scope_opt_in_language_servers = [
+    "elixir-ls",
+    "expert",
+    "next-ls",
+    "lexical",
+]
+
+[overrides.elixir]
+opt_into_language_servers = [
+    "elixir-ls",
+    "expert",
+    "next-ls",
+    "lexical",
+]

--- a/languages/eex/overrides.scm
+++ b/languages/eex/overrides.scm
@@ -1,3 +1,4 @@
+; Comments
 [
   (comment
     "<%!--"
@@ -6,3 +7,6 @@
     "<%#"
     "%>")
 ] @comment
+
+; Elixir expressions
+(directive) @elixir

--- a/languages/elixir/config.toml
+++ b/languages/elixir/config.toml
@@ -12,30 +12,39 @@ brackets = [
         "comment",
         "string",
         "quoted_atom",
-        "sigil_string",
+        "sigil_quote",
     ] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = [
         "comment",
         "string",
         "quoted_atom",
-        "sigil_string",
+        "sigil_quote",
     ] },
     { start = "'''", end = "\n'''", close = true, newline = true, not_in = [
         "comment",
         "string",
         "quoted_atom",
-        "sigil_string",
+        "sigil_quote",
     ] },
     { start = "'", end = "'", close = true, newline = false, not_in = [
         "comment",
         "string",
         "quoted_atom",
-        "sigil_string",
+        "sigil_quote",
     ] },
 ]
 tab_size = 2
 decrease_indent_pattern = '^\s*(after|catch|else|rescue)$'
-scope_opt_in_language_servers = ["tailwindcss-language-server"]
+scope_opt_in_language_servers = [
+    "tailwindcss-language-server",
+    "emmet-language-server",
+]
+
+[overrides.heex]
+opt_into_language_servers = [
+    "tailwindcss-language-server",
+    "emmet-language-server",
+]
 
 [overrides.string]
 completion_query_characters = ["-"]

--- a/languages/elixir/overrides.scm
+++ b/languages/elixir/overrides.scm
@@ -1,15 +1,19 @@
+; Comments
 (comment) @comment.inclusive
 
+; Strings
 [
   (string)
   (charlist)
 ] @string
 
+; Quoted atoms
 [
   (quoted_atom)
   (quoted_keyword)
 ] @quoted_atom
 
+; Identifiers, atoms, and module attributes
 [
   (identifier)
   (atom)
@@ -18,24 +22,30 @@
     operator: "@")
 ] @identifier
 
+; Chars (e.g. `?\n`, `?\s`)
 (char) @char
 
+; Parameter placeholders when capturing anonymous functions
 (unary_operator
   operator: "&"
   operand: (integer)) @capture
 
+; Sigils using curly bracket delimiters
 (sigil
   quoted_start: "{"
   quoted_end: "}") @sigil_curly
 
+; Sigils using square bracket delimiters
 (sigil
   quoted_start: "["
   quoted_end: "]") @sigil_square
 
+; Sigils using round bracket delimiters
 (sigil
   quoted_start: "("
   quoted_end: ")") @sigil_round
 
+; Sigils using quote mark delimiters
 [
   (sigil
     quoted_start: "\"\"\""
@@ -49,4 +59,9 @@
   (sigil
     quoted_start: "'"
     quoted_end: "'")
-] @sigil_string
+] @sigil_quote
+
+; HEEx templates
+(sigil
+  (sigil_name) @_sigil_name
+  (#eq? @_sigil_name "H")) @heex

--- a/languages/heex/config.toml
+++ b/languages/heex/config.toml
@@ -15,11 +15,25 @@ brackets = [
     { start = "!--", end = " --", close = true, newline = false, not_in = ["comment", "string"] },
 ]
 tab_size = 2
-scope_opt_in_language_servers = ["tailwindcss-language-server"]
+scope_opt_in_language_servers = [
+    "elixir-ls",
+    "expert",
+    "next-ls",
+    "lexical",
+    "tailwindcss-language-server",
+]
+
+[overrides.elixir]
+opt_into_language_servers = [
+    "elixir-ls",
+    "expert",
+    "next-ls",
+    "lexical",
+]
 
 [overrides.string]
 completion_query_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]
 
-[overrides.function]
-word_characters = ["!", "?"]
+[overrides.identifier]
+word_characters = ["!", "?", "@"]

--- a/languages/heex/overrides.scm
+++ b/languages/heex/overrides.scm
@@ -1,8 +1,20 @@
+; Comments
 (comment) @comment
 
+; HEEx attribute values
 [
   (attribute_value)
   (quoted_attribute_value)
 ] @string
 
-(function) @function
+; Function and slot identifiers
+[
+  (function)
+  (slot_name)
+] @identifier
+
+; Elixir expressions
+[
+  (expression)
+  (directive)
+] @elixir


### PR DESCRIPTION
These allow us to restrict code completions into specific contexts:
- For Elixir files, Tailwind and Emmet will now give completions inside HEEx templates only, save for one caveat
  - Tailwind is still scoped into strings so that completions don't break if Elixir interpolation is used inside the class attribute of an HTML tag
- For EEx/HEEx files, ElixirLS, Expert, Next LS, and Lexical will now give completions inside Elixir expressions only - should fix #91

Additionally, this reworks the function override that was being used by HEEx into an identifier override that should cover slot names as well - with this change `@` will now be treated as a word character, just like Elixir