### PR TITLE
Add highlight capture for structs

### DIFF
--- a/.tsqueryrc.json
+++ b/.tsqueryrc.json
@@ -77,6 +77,7 @@
       "type.builtin": "Captures built-in types",
       "type.interface": "Captures interface types",
       "type.module": "Captures modules",
+      "type.module.struct": "Captures structs",
       "type.spec": "Captures typespecs",
       "type.super": "Captures superclass types",
       "variable": "Captures variables",

--- a/languages/elixir/highlights.scm
+++ b/languages/elixir/highlights.scm
@@ -70,6 +70,14 @@
       (quoted_atom)
     ] @type.module))
 
+; Structs
+(struct
+  [
+    (alias)
+    (atom)
+    (quoted_atom)
+  ] @type.module.struct)
+
 ; Regular identifiers
 (identifier) @variable
 


### PR DESCRIPTION
This introduces the `@type.module.struct` capture so that a different highlight from modules can be optionally applied