### PR TITLE
Split highlight capture for special atoms

### DIFF
--- a/languages/elixir/highlights.scm
+++ b/languages/elixir/highlights.scm
@@ -38,11 +38,11 @@
   (quoted_keyword)
 ] @string.special.symbol
 
-; Special atom literals
-[
-  (boolean)
-  (nil)
-] @constant
+; Boolean literals
+(boolean) @boolean
+
+; Nil literal
+(nil) @constant.builtin
 
 ; Number literals
 [


### PR DESCRIPTION
This separates the capture used by boolean and `nil` atoms; they should now be captured by `@boolean` and `@constant.builtin` respectively, like in other languages