### PR TITLE
Add Dexter Language Server support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "elixir"
 name = "Elixir"
 description = "Elixir support."
-version = "0.4.3"
+version = "0.4.4"
 schema_version = 1
 authors = [
     "Marshall Bowers <elliott.codes@gmail.com>",

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "elixir"
 name = "Elixir"
 description = "Elixir support."
-version = "0.4.4"
+version = "0.4.3"
 schema_version = 1
 authors = [
     "Marshall Bowers <elliott.codes@gmail.com>",

--- a/extension.toml
+++ b/extension.toml
@@ -9,6 +9,17 @@ authors = [
 ]
 repository = "https://github.com/zed-extensions/elixir"
 
+[language_servers.dexter]
+name = "Dexter"
+languages = [
+    "Elixir",
+    "HEEx",
+]
+
+[language_servers.dexter.language_ids]
+"Elixir" = "elixir"
+"HEEx" = "heex"
+
 [language_servers.expert]
 name = "Expert"
 languages = [

--- a/extension.toml
+++ b/extension.toml
@@ -13,11 +13,13 @@ repository = "https://github.com/zed-extensions/elixir"
 name = "Dexter"
 languages = [
     "Elixir",
+    "EEx",
     "HEEx",
 ]
 
 [language_servers.dexter.language_ids]
 "Elixir" = "elixir"
+"EEx" = "eex"
 "HEEx" = "heex"
 
 [language_servers.expert]

--- a/extension.toml
+++ b/extension.toml
@@ -9,19 +9,6 @@ authors = [
 ]
 repository = "https://github.com/zed-extensions/elixir"
 
-[language_servers.dexter]
-name = "Dexter"
-languages = [
-    "Elixir",
-    "EEx",
-    "HEEx",
-]
-
-[language_servers.dexter.language_ids]
-"Elixir" = "elixir"
-"EEx" = "eex"
-"HEEx" = "heex"
-
 [language_servers.expert]
 name = "Expert"
 languages = [
@@ -44,6 +31,19 @@ languages = [
 ]
 
 [language_servers.elixir-ls.language_ids]
+"Elixir" = "elixir"
+"EEx" = "eex"
+"HEEx" = "heex"
+
+[language_servers.dexter]
+name = "Dexter"
+languages = [
+    "Elixir",
+    "EEx",
+    "HEEx",
+]
+
+[language_servers.dexter.language_ids]
 "Elixir" = "elixir"
 "EEx" = "eex"
 "HEEx" = "heex"

--- a/src/elixir.rs
+++ b/src/elixir.rs
@@ -9,9 +9,9 @@ use zed_extension_api::{
 use crate::language_servers::{Dexter, ElixirLs, Expert, Lexical, NextLs};
 
 struct ElixirExtension {
-    dexter: Option<Dexter>,
     expert: Option<Expert>,
     elixir_ls: Option<ElixirLs>,
+    dexter: Option<Dexter>,
     next_ls: Option<NextLs>,
     lexical: Option<Lexical>,
 }
@@ -19,9 +19,9 @@ struct ElixirExtension {
 impl zed::Extension for ElixirExtension {
     fn new() -> Self {
         Self {
-            dexter: None,
             expert: None,
             elixir_ls: None,
+            dexter: None,
             next_ls: None,
             lexical: None,
         }
@@ -33,10 +33,6 @@ impl zed::Extension for ElixirExtension {
         worktree: &Worktree,
     ) -> Result<zed::Command> {
         match language_server_id.as_ref() {
-            Dexter::LANGUAGE_SERVER_ID => self
-                .dexter
-                .get_or_insert_with(Dexter::new)
-                .language_server_command(language_server_id, worktree),
             Expert::LANGUAGE_SERVER_ID => self
                 .expert
                 .get_or_insert_with(Expert::new)
@@ -44,6 +40,10 @@ impl zed::Extension for ElixirExtension {
             ElixirLs::LANGUAGE_SERVER_ID => self
                 .elixir_ls
                 .get_or_insert_with(ElixirLs::new)
+                .language_server_command(language_server_id, worktree),
+            Dexter::LANGUAGE_SERVER_ID => self
+                .dexter
+                .get_or_insert_with(Dexter::new)
                 .language_server_command(language_server_id, worktree),
             NextLs::LANGUAGE_SERVER_ID => self
                 .next_ls
@@ -63,10 +63,6 @@ impl zed::Extension for ElixirExtension {
         worktree: &Worktree,
     ) -> Result<Option<Value>> {
         match language_server_id.as_ref() {
-            Dexter::LANGUAGE_SERVER_ID => self
-                .dexter
-                .get_or_insert_with(Dexter::new)
-                .language_server_initialization_options(worktree),
             Expert::LANGUAGE_SERVER_ID => self
                 .expert
                 .get_or_insert_with(Expert::new)
@@ -74,6 +70,10 @@ impl zed::Extension for ElixirExtension {
             ElixirLs::LANGUAGE_SERVER_ID => self
                 .elixir_ls
                 .get_or_insert_with(ElixirLs::new)
+                .language_server_initialization_options(worktree),
+            Dexter::LANGUAGE_SERVER_ID => self
+                .dexter
+                .get_or_insert_with(Dexter::new)
                 .language_server_initialization_options(worktree),
             NextLs::LANGUAGE_SERVER_ID => self
                 .next_ls
@@ -93,10 +93,6 @@ impl zed::Extension for ElixirExtension {
         worktree: &Worktree,
     ) -> Result<Option<Value>> {
         match language_server_id.as_ref() {
-            Dexter::LANGUAGE_SERVER_ID => self
-                .dexter
-                .get_or_insert_with(Dexter::new)
-                .language_server_workspace_configuration(worktree),
             Expert::LANGUAGE_SERVER_ID => self
                 .expert
                 .get_or_insert_with(Expert::new)
@@ -104,6 +100,10 @@ impl zed::Extension for ElixirExtension {
             ElixirLs::LANGUAGE_SERVER_ID => self
                 .elixir_ls
                 .get_or_insert_with(ElixirLs::new)
+                .language_server_workspace_configuration(worktree),
+            Dexter::LANGUAGE_SERVER_ID => self
+                .dexter
+                .get_or_insert_with(Dexter::new)
                 .language_server_workspace_configuration(worktree),
             NextLs::LANGUAGE_SERVER_ID => self
                 .next_ls
@@ -123,11 +123,11 @@ impl zed::Extension for ElixirExtension {
         completion: Completion,
     ) -> Option<CodeLabel> {
         match language_server_id.as_ref() {
-            Dexter::LANGUAGE_SERVER_ID => self.dexter.as_ref()?.label_for_completion(completion),
             Expert::LANGUAGE_SERVER_ID => self.expert.as_ref()?.label_for_completion(completion),
             ElixirLs::LANGUAGE_SERVER_ID => {
                 self.elixir_ls.as_ref()?.label_for_completion(completion)
             }
+            Dexter::LANGUAGE_SERVER_ID => self.dexter.as_ref()?.label_for_completion(completion),
             NextLs::LANGUAGE_SERVER_ID => self.next_ls.as_ref()?.label_for_completion(completion),
             Lexical::LANGUAGE_SERVER_ID => self.lexical.as_ref()?.label_for_completion(completion),
             _ => None,
@@ -140,9 +140,9 @@ impl zed::Extension for ElixirExtension {
         symbol: Symbol,
     ) -> Option<CodeLabel> {
         match language_server_id.as_ref() {
-            Dexter::LANGUAGE_SERVER_ID => self.dexter.as_ref()?.label_for_symbol(symbol),
             Expert::LANGUAGE_SERVER_ID => self.expert.as_ref()?.label_for_symbol(symbol),
             ElixirLs::LANGUAGE_SERVER_ID => self.elixir_ls.as_ref()?.label_for_symbol(symbol),
+            Dexter::LANGUAGE_SERVER_ID => self.dexter.as_ref()?.label_for_symbol(symbol),
             NextLs::LANGUAGE_SERVER_ID => self.next_ls.as_ref()?.label_for_symbol(symbol),
             Lexical::LANGUAGE_SERVER_ID => self.lexical.as_ref()?.label_for_symbol(symbol),
             _ => None,

--- a/src/elixir.rs
+++ b/src/elixir.rs
@@ -6,9 +6,10 @@ use zed_extension_api::{
     serde_json::Value,
 };
 
-use crate::language_servers::{ElixirLs, Expert, Lexical, NextLs};
+use crate::language_servers::{Dexter, ElixirLs, Expert, Lexical, NextLs};
 
 struct ElixirExtension {
+    dexter: Option<Dexter>,
     expert: Option<Expert>,
     elixir_ls: Option<ElixirLs>,
     next_ls: Option<NextLs>,
@@ -18,6 +19,7 @@ struct ElixirExtension {
 impl zed::Extension for ElixirExtension {
     fn new() -> Self {
         Self {
+            dexter: None,
             expert: None,
             elixir_ls: None,
             next_ls: None,
@@ -31,6 +33,10 @@ impl zed::Extension for ElixirExtension {
         worktree: &Worktree,
     ) -> Result<zed::Command> {
         match language_server_id.as_ref() {
+            Dexter::LANGUAGE_SERVER_ID => self
+                .dexter
+                .get_or_insert_with(Dexter::new)
+                .language_server_command(language_server_id, worktree),
             Expert::LANGUAGE_SERVER_ID => self
                 .expert
                 .get_or_insert_with(Expert::new)
@@ -57,6 +63,10 @@ impl zed::Extension for ElixirExtension {
         worktree: &Worktree,
     ) -> Result<Option<Value>> {
         match language_server_id.as_ref() {
+            Dexter::LANGUAGE_SERVER_ID => self
+                .dexter
+                .get_or_insert_with(Dexter::new)
+                .language_server_initialization_options(worktree),
             Expert::LANGUAGE_SERVER_ID => self
                 .expert
                 .get_or_insert_with(Expert::new)
@@ -83,6 +93,10 @@ impl zed::Extension for ElixirExtension {
         worktree: &Worktree,
     ) -> Result<Option<Value>> {
         match language_server_id.as_ref() {
+            Dexter::LANGUAGE_SERVER_ID => self
+                .dexter
+                .get_or_insert_with(Dexter::new)
+                .language_server_workspace_configuration(worktree),
             Expert::LANGUAGE_SERVER_ID => self
                 .expert
                 .get_or_insert_with(Expert::new)
@@ -109,6 +123,7 @@ impl zed::Extension for ElixirExtension {
         completion: Completion,
     ) -> Option<CodeLabel> {
         match language_server_id.as_ref() {
+            Dexter::LANGUAGE_SERVER_ID => self.dexter.as_ref()?.label_for_completion(completion),
             Expert::LANGUAGE_SERVER_ID => self.expert.as_ref()?.label_for_completion(completion),
             ElixirLs::LANGUAGE_SERVER_ID => {
                 self.elixir_ls.as_ref()?.label_for_completion(completion)
@@ -125,6 +140,7 @@ impl zed::Extension for ElixirExtension {
         symbol: Symbol,
     ) -> Option<CodeLabel> {
         match language_server_id.as_ref() {
+            Dexter::LANGUAGE_SERVER_ID => self.dexter.as_ref()?.label_for_symbol(symbol),
             Expert::LANGUAGE_SERVER_ID => self.expert.as_ref()?.label_for_symbol(symbol),
             ElixirLs::LANGUAGE_SERVER_ID => self.elixir_ls.as_ref()?.label_for_symbol(symbol),
             NextLs::LANGUAGE_SERVER_ID => self.next_ls.as_ref()?.label_for_symbol(symbol),

--- a/src/language_servers.rs
+++ b/src/language_servers.rs
@@ -1,10 +1,12 @@
 mod config;
+mod dexter;
 mod elixir_ls;
 mod expert;
 mod lexical;
 mod next_ls;
 mod util;
 
+pub use dexter::*;
 pub use elixir_ls::*;
 pub use expert::*;
 pub use lexical::*;

--- a/src/language_servers/dexter.rs
+++ b/src/language_servers/dexter.rs
@@ -47,16 +47,13 @@ impl Dexter {
     ) -> Result<DexterBinary> {
         let (platform, arch) = zed::current_platform();
 
-        if matches!(platform, zed::Os::Windows) {
-            return Err("Dexter does not support Windows".to_string());
-        }
-
-        let platform_suffix = format!(
-            "{os}_{arch}",
+        let archive_name = format!(
+            "{}_{os}_{arch}",
+            Self::LANGUAGE_SERVER_ID,
             os = match platform {
                 zed::Os::Mac => "Darwin",
                 zed::Os::Linux => "Linux",
-                zed::Os::Windows => unreachable!(),
+                zed::Os::Windows => return Err(format!("unsupported platform: {platform:?}")),
             },
             arch = match arch {
                 zed::Architecture::Aarch64 => "arm64",
@@ -66,6 +63,7 @@ impl Dexter {
             },
         );
 
+        let binary_name = format!("{}/{}", archive_name, Self::LANGUAGE_SERVER_ID);
         let binary_settings = config::get_binary_settings(Self::LANGUAGE_SERVER_ID, worktree);
         let binary_args = config::get_binary_args(&binary_settings)
             .unwrap_or_else(|| vec!["lsp".to_string()]);
@@ -107,7 +105,6 @@ impl Dexter {
         ) {
             Ok(release) => release,
             Err(_) => {
-                let binary_name = format!("dexter_{platform_suffix}/dexter");
                 if let Some(binary_path) =
                     util::find_existing_binary(Self::LANGUAGE_SERVER_ID, &binary_name)
                 {
@@ -121,8 +118,7 @@ impl Dexter {
             }
         };
 
-        let asset_name = format!("dexter_{platform_suffix}.tar.gz");
-
+        let asset_name = format!("{archive_name}.tar.gz");
         let asset = release
             .assets
             .iter()
@@ -132,7 +128,7 @@ impl Dexter {
         let version_dir = format!("{}-{}", Self::LANGUAGE_SERVER_ID, release.version);
         fs::create_dir_all(&version_dir).map_err(|e| format!("failed to create directory: {e}"))?;
 
-        let binary_path = format!("{version_dir}/dexter_{platform_suffix}/dexter");
+        let binary_path = format!("{}/{}", version_dir, binary_name);
 
         if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
             zed::set_language_server_installation_status(

--- a/src/language_servers/dexter.rs
+++ b/src/language_servers/dexter.rs
@@ -46,7 +46,6 @@ impl Dexter {
         worktree: &Worktree,
     ) -> Result<DexterBinary> {
         let (platform, arch) = zed::current_platform();
-
         let archive_name = format!(
             "{}_{os}_{arch}",
             Self::LANGUAGE_SERVER_ID,
@@ -126,8 +125,6 @@ impl Dexter {
             .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
 
         let version_dir = format!("{}-{}", Self::LANGUAGE_SERVER_ID, release.version);
-        fs::create_dir_all(&version_dir).map_err(|e| format!("failed to create directory: {e}"))?;
-
         let binary_path = format!("{}/{}", version_dir, binary_name);
 
         if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {

--- a/src/language_servers/dexter.rs
+++ b/src/language_servers/dexter.rs
@@ -65,8 +65,8 @@ impl Dexter {
 
         let binary_name = format!("{}/{}", archive_name, Self::LANGUAGE_SERVER_ID);
         let binary_settings = config::get_binary_settings(Self::LANGUAGE_SERVER_ID, worktree);
-        let binary_args = config::get_binary_args(&binary_settings)
-            .unwrap_or_else(|| vec!["lsp".to_string()]);
+        let binary_args =
+            config::get_binary_args(&binary_settings).unwrap_or_else(|| vec!["lsp".to_string()]);
 
         if let Some(binary_path) = config::get_binary_path(&binary_settings) {
             return Ok(DexterBinary {

--- a/src/language_servers/dexter.rs
+++ b/src/language_servers/dexter.rs
@@ -1,0 +1,243 @@
+use std::fs;
+
+use zed_extension_api::{
+    self as zed, CodeLabel, CodeLabelSpan, LanguageServerId, Result, Worktree,
+    lsp::{Completion, CompletionKind, Symbol, SymbolKind},
+    serde_json::{Value, json},
+};
+
+use crate::language_servers::{config, util};
+
+struct DexterBinary {
+    path: String,
+    args: Vec<String>,
+}
+
+pub struct Dexter {
+    cached_binary_path: Option<String>,
+}
+
+impl Dexter {
+    pub const LANGUAGE_SERVER_ID: &'static str = "dexter";
+
+    pub fn new() -> Self {
+        Self {
+            cached_binary_path: None,
+        }
+    }
+
+    pub fn language_server_command(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<zed::Command> {
+        let dexter = self.language_server_binary(language_server_id, worktree)?;
+
+        Ok(zed::Command {
+            command: dexter.path,
+            args: dexter.args,
+            env: Default::default(),
+        })
+    }
+
+    fn language_server_binary(
+        &mut self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<DexterBinary> {
+        let (platform, arch) = zed::current_platform();
+
+        if matches!(platform, zed::Os::Windows) {
+            return Err("Dexter does not support Windows".to_string());
+        }
+
+        let platform_suffix = format!(
+            "{os}_{arch}",
+            os = match platform {
+                zed::Os::Mac => "Darwin",
+                zed::Os::Linux => "Linux",
+                zed::Os::Windows => unreachable!(),
+            },
+            arch = match arch {
+                zed::Architecture::Aarch64 => "arm64",
+                zed::Architecture::X8664 => "x86_64",
+                zed::Architecture::X86 =>
+                    return Err(format!("unsupported architecture: {arch:?}")),
+            },
+        );
+
+        let binary_settings = config::get_binary_settings(Self::LANGUAGE_SERVER_ID, worktree);
+        let binary_args = config::get_binary_args(&binary_settings)
+            .unwrap_or_else(|| vec!["lsp".to_string()]);
+
+        if let Some(binary_path) = config::get_binary_path(&binary_settings) {
+            return Ok(DexterBinary {
+                path: binary_path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(binary_path) = worktree.which(Self::LANGUAGE_SERVER_ID) {
+            return Ok(DexterBinary {
+                path: binary_path,
+                args: binary_args,
+            });
+        }
+
+        if let Some(binary_path) = &self.cached_binary_path
+            && fs::metadata(binary_path).is_ok_and(|stat| stat.is_file())
+        {
+            return Ok(DexterBinary {
+                path: binary_path.clone(),
+                args: binary_args,
+            });
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+
+        let release = match zed::latest_github_release(
+            "remoteoss/dexter",
+            zed::GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        ) {
+            Ok(release) => release,
+            Err(_) => {
+                let binary_name = format!("dexter_{platform_suffix}/dexter");
+                if let Some(binary_path) =
+                    util::find_existing_binary(Self::LANGUAGE_SERVER_ID, &binary_name)
+                {
+                    self.cached_binary_path = Some(binary_path.clone());
+                    return Ok(DexterBinary {
+                        path: binary_path,
+                        args: binary_args,
+                    });
+                }
+                return Err("failed to download latest github release".to_string());
+            }
+        };
+
+        let asset_name = format!("dexter_{platform_suffix}.tar.gz");
+
+        let asset = release
+            .assets
+            .iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+
+        let version_dir = format!("{}-{}", Self::LANGUAGE_SERVER_ID, release.version);
+        fs::create_dir_all(&version_dir).map_err(|e| format!("failed to create directory: {e}"))?;
+
+        let binary_path = format!("{version_dir}/dexter_{platform_suffix}/dexter");
+
+        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(
+                &asset.download_url,
+                &version_dir,
+                zed::DownloadedFileType::GzipTar,
+            )
+            .map_err(|e| format!("failed to download file: {e}"))?;
+
+            zed::make_file_executable(&binary_path)?;
+
+            util::remove_outdated_versions(Self::LANGUAGE_SERVER_ID, &version_dir)?;
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+        Ok(DexterBinary {
+            path: binary_path,
+            args: binary_args,
+        })
+    }
+
+    pub fn language_server_initialization_options(
+        &mut self,
+        worktree: &Worktree,
+    ) -> Result<Option<Value>> {
+        let settings = config::get_initialization_options(Self::LANGUAGE_SERVER_ID, worktree)
+            .unwrap_or_else(|| {
+                json!({
+                    "followDelegates": true
+                })
+            });
+
+        Ok(Some(settings))
+    }
+
+    pub fn language_server_workspace_configuration(
+        &mut self,
+        worktree: &Worktree,
+    ) -> Result<Option<Value>> {
+        let settings = config::get_workspace_configuration(Self::LANGUAGE_SERVER_ID, worktree)
+            .unwrap_or_default();
+
+        Ok(Some(settings))
+    }
+
+    pub fn label_for_completion(&self, completion: Completion) -> Option<CodeLabel> {
+        match completion.kind? {
+            CompletionKind::Module | CompletionKind::Class => {
+                let name = completion.label;
+                let defmodule = "defmodule ";
+                let code = format!("{defmodule}{name}");
+
+                Some(CodeLabel {
+                    code,
+                    spans: vec![CodeLabelSpan::code_range(
+                        defmodule.len()..defmodule.len() + name.len(),
+                    )],
+                    filter_range: (0..name.len()).into(),
+                })
+            }
+            CompletionKind::Function | CompletionKind::Constant => {
+                let name = completion.label;
+                let def = "def ";
+                let code = format!("{def}{name}");
+
+                Some(CodeLabel {
+                    code,
+                    spans: vec![CodeLabelSpan::code_range(def.len()..def.len() + name.len())],
+                    filter_range: (0..name.len()).into(),
+                })
+            }
+            _ => None,
+        }
+    }
+
+    pub fn label_for_symbol(&self, symbol: Symbol) -> Option<CodeLabel> {
+        let name = &symbol.name;
+
+        let (code, filter_range, display_range) = match symbol.kind {
+            SymbolKind::Module | SymbolKind::Interface | SymbolKind::Struct => {
+                let defmodule = "defmodule ";
+                let code = format!("{defmodule}{name}");
+                let filter_range = 0..name.len();
+                let display_range = defmodule.len()..defmodule.len() + name.len();
+                (code, filter_range, display_range)
+            }
+            SymbolKind::Function | SymbolKind::Constant => {
+                let def = "def ";
+                let code = format!("{def}{name}");
+                let filter_range = 0..name.len();
+                let display_range = def.len()..def.len() + name.len();
+                (code, filter_range, display_range)
+            }
+            _ => return None,
+        };
+
+        Some(CodeLabel {
+            spans: vec![CodeLabelSpan::code_range(display_range)],
+            filter_range: filter_range.into(),
+            code,
+        })
+    }
+}


### PR DESCRIPTION
## Summary

  Add [Dexter](https://github.com/remoteoss/dexter) as another language server in the Elixir extension.
  
  Read more on the [Elixir forum](https://elixirforum.com/t/dexter-a-fast-full-featured-elixir-lsp-optimized-for-large-codebases/74963).

  Dexter is a fast, full-featured Elixir LSP written in Go, optimized for large codebases. It was built by Remote's engineering team to solve performance issues with existing LSP solutions on their 57k-file Elixir monorepo, where traditional approaches took hours to index. 
  Dexter works by parsing source files directly and storing results in SQLite, requiring no compilation.

  Key capabilities & highlights
  - Go-to-definition across modules, functions, types, delegates, and imports
  - Find references, hover docs, autocompletion with snippet support
  - Rename (modules, functions, variables with automatic file renaming)
  - Format on save via persistent Elixir process
  - Monorepo and umbrella project support
  - Cold index ~11s on 57k files, lookups ~10ms, reindex ~2s
  - Supports Elixir and HEEx languages
  - Default command: `dexter lsp`
  - Platform support: macOS (ARM64), Linux (x86_64, ARM64)

  ## Configuration

  ```
  {
    "lsp": {
      "dexter": {
        "binary": {
          "path": "/path/to/dexter",
          "arguments": ["lsp"]
        },
        "initialization_options": {
          "followDelegates": true
        }
      }
    }
  }

  // Enable in language settings:
  {
    "languages": {
      "Elixir": {
        "language_servers": ["dexter", "!expert", "..."]
      }
    }
  }
```

  ## Testing

- [x] Install as dev extension in Zed
- [x] Check it auto-downloads from GitHub releases (binary at dexter-v0.5.3/dexter_Darwin_arm64/dexter)
- [x] Check Go-to-definition works via Dexter
- [x] User settings override for binary path works
